### PR TITLE
fix: 未提出課題数が0件のときに成績更新通知の設定が表示されない

### DIFF
--- a/src/Comfortable_Gakujo.user.js
+++ b/src/Comfortable_Gakujo.user.js
@@ -498,7 +498,17 @@
             waitForCountElement.observe(document.body, { childList: true, subtree: true });
             showUpdateNotice();
 
-            const mediumSizeItems = document.getElementById("mediumSizeItems");
+            const indexMainVisualNotice = document.getElementsByClassName("index-main-visual-notice")[0];
+            if (!indexMainVisualNotice.querySelector(".index-main-visual-notice-other")) {
+                const indexMainVisualNoticeOther = document.createElement("div");
+                indexMainVisualNoticeOther.className = "index-main-visual-notice-other";
+                const ul = document.createElement("ul");
+                ul.className = "index-notice-other-items";
+                indexMainVisualNoticeOther.appendChild(ul);
+                indexMainVisualNotice.appendChild(indexMainVisualNoticeOther);
+            }
+
+            const indexNoticeOtherItems = document.getElementsByClassName("index-notice-other-items")[0];
             const li = document.createElement('li');
             li.className = 'index-notice-other-item';
             if (getCookie("cg_grade_save_enabled") === "1") {
@@ -693,7 +703,7 @@
                 }
                 `;
             document.head.appendChild(style);
-            mediumSizeItems.appendChild(li);
+            indexNoticeOtherItems.appendChild(li);
 
             window.addEventListener('change', (e) => {
                 if (e.target.id === 'cg-grade-save-toggle') {


### PR DESCRIPTION
## 概要

トップページにおいて、未提出課題の有無によって成績更新通知の設定が意図しない要素に追加されていまい、表示されない不具合を修正しました。

## 背景

トップページには `#mediumSizeItems` という ID を持つ要素が 2 つ存在しており、未提出課題のステータスによって挙動が変化します。

- 未提出課題がある場合: 1つ目の `#mediumSizeItems` に正しく通知設定が追加される。
- 未提出課題がない場合: 1つ目の `#mediumSizeItems` が消滅するため、2つ目の `#mediumSizeItems` に設定を追加する。画面上に設定が表示されない。

<img width="475" height="298" alt="image" src="https://github.com/user-attachments/assets/b126c6af-dd20-4790-8088-80738a21db82" />

## 変更内容

- `.index-main-visual-notice .index-main-visual-notice-other` の存在を確認する。要素が存在しない場合は、設定を追加するための要素を追加。